### PR TITLE
Configurable policy for route data revisions

### DIFF
--- a/src/main/resources/application-context.xml
+++ b/src/main/resources/application-context.xml
@@ -297,6 +297,8 @@
                 <bean class="net.contargo.iris.route.service.RouteDataRevisionPartEnricher">
                     <constructor-arg name="routeDataRevisionService" ref="routeDataRevisionService"/>
                     <constructor-arg name="addressListFilter" ref="addressListFilter"/>
+                    <constructor-arg name="routeDataRevisionPolicy"
+                                     value="#{'${routeDataRevision.mandatoryForSwissAddress}' ? 'MANDATORY_FOR_SWISS_ADDRESS' : 'OPTIONAL'}"/>
                 </bean>
             </list>
         </constructor-arg>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,3 +50,5 @@ feature.dtruck=false
 cookies.link=https://example.com
 
 routing.threads=10
+
+routeDataRevision.mandatoryForSwissAddress=true


### PR DESCRIPTION
Configuration property
    routeDataRevision.mandatoryForSwissAddress
controls whether route data revisions are mandatory for routings
to Swiss addresses. Allowed values: true, false